### PR TITLE
feat(chat): show bash commands, highlight read results, render edit diffs

### DIFF
--- a/src/components/chat/tool-use-card.tsx
+++ b/src/components/chat/tool-use-card.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { memo } from "react";
-import { ChevronDown, ChevronRight, Wrench, AlertCircle, CheckCircle2, CircleSlash, Bot, Check } from "lucide-react";
+import { memo, useMemo } from "react";
+import { ChevronDown, ChevronRight, Wrench, AlertCircle, CheckCircle2, CircleSlash, Bot, Check, FileDiff } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { Spinner } from "@/components/ui/spinner";
 import { AnsiText } from "@/components/ui/ansi-text";
+import { fileExtension, highlightSource, HLJS_THEME_CLASS, languageForExtension } from "@/lib/highlight";
 import type { PiContentBlock, RenderedBlock } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "@/lib/i18n";
@@ -86,6 +87,236 @@ function stringifyArgs(args: unknown): string {
   }
 }
 
+/** Extract the file path from a read-style tool call (path/file/file_path
+ *  arg, possibly stringified JSON), or null when there isn't one. */
+function toolFilePath(args: unknown): string | null {
+  let value: unknown = args;
+  if (typeof args === "string") {
+    try {
+      value = JSON.parse(args);
+    } catch {
+      value = args;
+    }
+  }
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    for (const k of ["path", "file", "file_path", "filename"]) {
+      const v = obj[k];
+      if (typeof v === "string" && v.trim()) return v.trim();
+    }
+  }
+  return null;
+}
+
+/** One oldText→newText replacement inside an edit tool call. */
+interface EditSpec {
+  oldText: string;
+  newText: string;
+}
+
+/** A single line of a computed diff. */
+interface DiffLine {
+  type: "add" | "del" | "same";
+  text: string;
+}
+
+interface EditInfo {
+  path: string | null;
+  edits: EditSpec[];
+}
+
+/** Extract the replacement pairs from an edit-style tool call (an `edits`
+ *  array, or a bare { oldText, newText } pair — possibly stringified JSON).
+ *  Null when there's nothing diff-shaped to show. */
+function editChanges(args: unknown): EditInfo | null {
+  let value: unknown = args;
+  if (typeof args === "string") {
+    try {
+      value = JSON.parse(args);
+    } catch {
+      value = args;
+    }
+  }
+  if (!value || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  let path: string | null = null;
+  for (const k of ["path", "file", "file_path", "filename"]) {
+    const v = obj[k];
+    if (typeof v === "string" && v.trim()) {
+      path = v.trim();
+      break;
+    }
+  }
+  const edits: EditSpec[] = [];
+  const push = (e: Record<string, unknown>) => {
+    const oldText = typeof e.oldText === "string" ? e.oldText : "";
+    const newText = typeof e.newText === "string" ? e.newText : "";
+    if (oldText || newText) edits.push({ oldText, newText });
+  };
+  if (Array.isArray(obj.edits)) {
+    for (const e of obj.edits) {
+      if (e && typeof e === "object") push(e as Record<string, unknown>);
+    }
+  } else if (obj.edits && typeof obj.edits === "object") {
+    push(obj.edits as Record<string, unknown>);
+  } else if (typeof obj.oldText === "string" || typeof obj.newText === "string") {
+    push(obj);
+  }
+  return edits.length > 0 ? { path, edits } : null;
+}
+
+// Guard against pathological oldText/newText sizes that would make the LCS
+// table explode — beyond this cap, fall back to a straight "removals then
+// additions" dump (still correct, just not minimal).
+const MAX_DIFF_LINES = 800;
+
+/** Line diff of two strings via LCS. Empty old/new sides produce pure
+ *  additions / deletions. */
+function diffLines(oldText: string, newText: string): DiffLine[] {
+  if (oldText === "") return newText.split("\n").map((text) => ({ type: "add" as const, text }));
+  if (newText === "") return oldText.split("\n").map((text) => ({ type: "del" as const, text }));
+  const a = oldText.split("\n");
+  const b = newText.split("\n");
+  if (a.length > MAX_DIFF_LINES || b.length > MAX_DIFF_LINES) {
+    return [
+      ...a.map((text) => ({ type: "del" as const, text })),
+      ...b.map((text) => ({ type: "add" as const, text })),
+    ];
+  }
+  const n = a.length;
+  const m = b.length;
+  // dp[i][j] = LCS length of a[i..] and b[j..] — walking backwards keeps the
+  // reconstruction (which only ever looks at dp[i+1] / dp[i][j+1]) in one pass.
+  const dp: Uint32Array[] = Array.from({ length: n + 1 }, () => new Uint32Array(m + 1));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ type: "same", text: a[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ type: "del", text: a[i] });
+      i++;
+    } else {
+      out.push({ type: "add", text: b[j] });
+      j++;
+    }
+  }
+  while (i < n) out.push({ type: "del", text: a[i++] });
+  while (j < m) out.push({ type: "add", text: b[j++] });
+  return out;
+}
+
+/** GitHub-style red/green line colors for a unified diff. */
+const DIFF_ADD_CLASS = "bg-[#dafbe1]/40 text-[#116329] dark:bg-[#033a16]/40 dark:text-[#aff5b4]";
+const DIFF_DEL_CLASS = "bg-[#ffebe9]/40 text-[#82071e] dark:bg-[#490202]/40 dark:text-[#ffdcd7]";
+
+function countDiff(diffs: DiffLine[][]): { adds: number; dels: number } {
+  let adds = 0;
+  let dels = 0;
+  for (const d of diffs) {
+    for (const l of d) {
+      if (l.type === "add") adds++;
+      else if (l.type === "del") dels++;
+    }
+  }
+  return { adds, dels };
+}
+
+/** Terminal-ish unified diff for one edit tool call: file header with a
+ *  diffstat, then `-`/`+` lines colored like git. Diffs are computed once by
+ *  the parent (memoized on the args) and passed in. */
+function EditDiffView({
+  path,
+  edits,
+  diffs,
+  stat,
+}: {
+  path: string | null;
+  edits: EditSpec[];
+  diffs: DiffLine[][];
+  stat: { adds: number; dels: number };
+}) {
+  return (
+    <div className="overflow-hidden rounded bg-background/60">
+      {path && (
+        <div className="flex items-center gap-1.5 border-b border-border/40 bg-muted/40 px-2 py-1 font-mono text-[10px] text-muted-foreground">
+          <FileDiff className="h-3 w-3 shrink-0" />
+          <span className="min-w-0 truncate" title={path}>
+            {path}
+          </span>
+          <span className="ml-auto shrink-0 text-success">+{stat.adds}</span>
+          <span className="shrink-0 text-destructive">-{stat.dels}</span>
+        </div>
+      )}
+      <div className="max-h-64 overflow-auto">
+        {diffs.map((d, i) => (
+          <div key={i}>
+            {edits.length > 1 && (
+              <div className="border-y border-border/30 bg-muted/30 px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {i + 1} / {edits.length}
+              </div>
+            )}
+            <pre className="px-2 py-1 font-mono text-[11px] leading-relaxed">
+              {d.map((line, j) => (
+                <div
+                  key={j}
+                  className={cn(
+                    "flex whitespace-pre-wrap break-words",
+                    line.type === "add"
+                      ? DIFF_ADD_CLASS
+                      : line.type === "del"
+                        ? DIFF_DEL_CLASS
+                        : "text-muted-foreground",
+                  )}
+                >
+                  <span className="w-4 shrink-0 select-none text-center">
+                    {line.type === "add" ? "+" : line.type === "del" ? "-" : ""}
+                  </span>
+                  <span className="min-w-0">{line.text || " "}</span>
+                </div>
+              ))}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Extract the shell command from a bash-style tool call — the tool name
+ *  mentions bash, or the args carry a `command`/`cmd` field (a command runner
+ *  by any name). Handles both object args ({ command: "…" }) and stringified
+ *  JSON. Returns null when there's nothing command-shaped to show; the caller
+ *  then falls back to the raw JSON args. */
+function bashCommand(name: string, args: unknown): string | null {
+  let value: unknown = args;
+  if (typeof args === "string") {
+    try {
+      value = JSON.parse(args);
+    } catch {
+      value = args;
+    }
+  }
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    for (const k of ["command", "cmd"]) {
+      const v = obj[k];
+      if (typeof v === "string" && v.trim()) return v;
+    }
+  }
+  // A bare-string arg on a bash-named tool is the command itself.
+  if (typeof value === "string" && value.trim() && /bash/i.test(name)) return value;
+  return null;
+}
+
 /** A short, single-line preview of a tool's args — the most useful field
  *  flattened to one line (e.g. a bash command, a file path, a query). Shown
  *  dimmed next to the tool name so a collapsed step still says what it did. */
@@ -136,6 +367,23 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
   const { t } = useTranslation("chat");
   const [open, toggle] = useDisclosure(id);
   const isError = block.result?.isError;
+  // Read-style tools surface file contents; highlight the result by the file's
+  // extension when we can pin a language, so a settled `read` shows colored
+  // code instead of a plain dump. Skipped on errors (keep the warning tint).
+  const resultText = block.result
+    ? Array.isArray(block.result.content)
+      ? flattenResultContent(block.result.content)
+      : ""
+    : "";
+  const readPath = /^read/i.test(block.name) ? toolFilePath(block.args) : null;
+  const readExt = readPath ? fileExtension(readPath) : "";
+  const highlighted = useMemo(
+    () =>
+      !isError && readPath !== null && languageForExtension(readExt)
+        ? highlightSource(resultText, readExt)
+        : null,
+    [isError, readPath, readExt, resultText],
+  );
   const subagent = subagentInfo(block.result?.details);
   const outputInfo = toolOutputInfo(block.result?.details);
   // Codex child threads may outlive the root turn, so agent_end can clear the
@@ -145,9 +393,20 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
   // — the run was aborted or pi died before the tool returned. Show a terminal
   // "interrupted" state instead of a spinner that never resolves.
   const isIncomplete = !isRunning && !isError && block.result == null;
+  const cmd = useMemo(() => bashCommand(block.name, block.args), [block.name, block.args]);
+  const editInfo = useMemo(() => editChanges(block.args), [block.args]);
+  const editDiffs = useMemo(
+    () => (editInfo ? editInfo.edits.map((e) => diffLines(e.oldText, e.newText)) : null),
+    [editInfo],
+  );
+  const editStat = useMemo(() => (editDiffs ? countDiff(editDiffs) : null), [editDiffs]);
   const preview = subagent
     ? [subagent.type, subagent.description].filter(Boolean).join(" — ")
-    : summarizeArgs(block.args);
+    : editInfo !== null && editStat !== null
+      ? `${editInfo.path ?? "edit"} · +${editStat.adds} -${editStat.dels}`
+      : cmd !== null
+        ? `$ ${cmd}`
+        : summarizeArgs(block.args);
   // Subagent steps: keep the list glanceable while running — last few steps
   // inline, the full history behind the expander.
   const steps = subagent?.steps ?? [];
@@ -214,25 +473,45 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
         <div className="space-y-2 px-2 pb-2 pt-1">
           {block.args != null && (
             <section>
-              <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">{t("tool.args")}</div>
-              <pre className="max-h-48 overflow-auto whitespace-pre-wrap rounded bg-background/60 px-2 py-1.5 font-mono text-[11px]">
-                {stringifyArgs(block.args)}
-              </pre>
+              <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                {editInfo !== null ? t("tool.diff") : cmd !== null ? t("tool.command") : t("tool.args")}
+              </div>
+              {editInfo !== null && editDiffs !== null && editStat !== null ? (
+                <EditDiffView path={editInfo.path} edits={editInfo.edits} diffs={editDiffs} stat={editStat} />
+              ) : cmd !== null ? (
+                <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-background/60 px-2 py-1.5 font-mono text-[11px] leading-relaxed">
+                  <span className="select-none text-muted-foreground">$ </span>
+                  {cmd}
+                </pre>
+              ) : (
+                <pre className="max-h-48 overflow-auto whitespace-pre-wrap rounded bg-background/60 px-2 py-1.5 font-mono text-[11px]">
+                  {stringifyArgs(block.args)}
+                </pre>
+              )}
             </section>
           )}
           {block.result && (
             <section>
               <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">{t("tool.result")}</div>
-              <pre
-                className={cn(
-                  "max-h-72 overflow-auto whitespace-pre-wrap rounded bg-background/60 px-2 py-1.5 font-mono text-[11px]",
-                  isError && "text-warning dark:text-warning",
-                )}
-              >
-                <AnsiText>
-                  {Array.isArray(block.result.content) ? flattenResultContent(block.result.content) : ""}
-                </AnsiText>
-              </pre>
+              {highlighted !== null ? (
+                <pre
+                  className={cn(
+                    "max-h-72 overflow-auto rounded bg-background/60 px-2 py-1.5 font-mono text-[11px] leading-relaxed",
+                    HLJS_THEME_CLASS,
+                  )}
+                >
+                  <code dangerouslySetInnerHTML={{ __html: highlighted }} />
+                </pre>
+              ) : (
+                <pre
+                  className={cn(
+                    "max-h-72 overflow-auto whitespace-pre-wrap rounded bg-background/60 px-2 py-1.5 font-mono text-[11px]",
+                    isError && "text-warning dark:text-warning",
+                  )}
+                >
+                  <AnsiText>{resultText}</AnsiText>
+                </pre>
+              )}
               {outputInfo?.truncated && (
                 <div className="mt-1 flex items-center justify-between gap-2 text-[10px] text-muted-foreground">
                   <span>{t("tool.outputTruncated", { size: formatBytes(outputInfo.totalBytes) })}</span>

--- a/src/components/chat/tool-use-card.tsx
+++ b/src/components/chat/tool-use-card.tsx
@@ -87,16 +87,19 @@ function stringifyArgs(args: unknown): string {
   }
 }
 
-/** Parsed read-style tool call: file path plus optional paging args. */
-interface ReadMeta {
+/** Parsed file-tool (read/write) call: path plus optional paging args, and
+ *  the written content size for write calls. */
+interface FileMeta {
   path: string | null;
   offset?: number;
   limit?: number;
+  /** Length of the `content` arg (write tool). */
+  size?: number;
 }
 
-/** Extract { path, offset, limit } from a read-style tool call (args may be an
- *  object or stringified JSON). */
-function readMeta(args: unknown): ReadMeta {
+/** Extract { path, offset, limit, size } from a read/write tool call (args may
+ *  be an object or stringified JSON). */
+function parseFileMeta(args: unknown): FileMeta {
   let value: unknown = args;
   if (typeof args === "string") {
     try {
@@ -105,7 +108,7 @@ function readMeta(args: unknown): ReadMeta {
       value = args;
     }
   }
-  const meta: ReadMeta = { path: null };
+  const meta: FileMeta = { path: null };
   if (value && typeof value === "object") {
     const obj = value as Record<string, unknown>;
     for (const k of ["path", "file", "file_path", "filename"]) {
@@ -122,6 +125,7 @@ function readMeta(args: unknown): ReadMeta {
     };
     meta.offset = num(obj.offset);
     meta.limit = num(obj.limit);
+    if (typeof obj.content === "string") meta.size = obj.content.length;
   }
   return meta;
 }
@@ -393,9 +397,12 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
       ? flattenResultContent(block.result.content)
       : ""
     : "";
-  const isReadTool = /^read/i.test(block.name);
-  const readMetaInfo = useMemo(() => (isReadTool ? readMeta(block.args) : null), [isReadTool, block.args]);
-  const readPath = readMetaInfo?.path ?? null;
+  const isFileTool = /^(read|write)/i.test(block.name);
+  const fileMeta = useMemo(() => (isFileTool ? parseFileMeta(block.args) : null), [isFileTool, block.args]);
+  const filePath = fileMeta?.path ?? null;
+  // Only read-style calls surface file *content* in the result — write calls
+  // return a confirmation string, so only they get the syntax highlight.
+  const readPath = /^read/i.test(block.name) ? filePath : null;
   const readExt = readPath ? fileExtension(readPath) : "";
   const highlighted = useMemo(
     () =>
@@ -420,6 +427,14 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
     [editInfo],
   );
   const editStat = useMemo(() => (editDiffs ? countDiff(editDiffs) : null), [editDiffs]);
+  // Trailing meta for the file header (read: offset/limit, write: size).
+  const fileMetaParts = useMemo(() => {
+    const parts: string[] = [];
+    if (fileMeta?.offset != null) parts.push(`offset ${fileMeta.offset}`);
+    if (fileMeta?.limit != null) parts.push(`limit ${fileMeta.limit}`);
+    if (fileMeta?.size != null) parts.push(formatBytes(fileMeta.size));
+    return parts;
+  }, [fileMeta]);
   const preview = subagent
     ? [subagent.type, subagent.description].filter(Boolean).join(" — ")
     : editInfo !== null && editStat !== null
@@ -491,9 +506,9 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
       )}
       {open && (
         <div className="space-y-2 px-2 pb-2 pt-1">
-          {/* Read-style tools skip the raw JSON args entirely — the path and
-              paging args surface as a header on the result instead. */}
-          {block.args != null && !isReadTool && (
+          {/* File tools (read/write) skip the raw JSON args entirely — the
+              path and paging/size args surface as a header on the result. */}
+          {block.args != null && !isFileTool && (
             <section>
               <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
                 {editInfo !== null ? t("tool.diff") : cmd !== null ? t("tool.command") : t("tool.args")}
@@ -515,18 +530,14 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
           {block.result && (
             <section>
               <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">{t("tool.result")}</div>
-              {readPath !== null && (
+              {filePath !== null && (
                 <div className="mb-1 flex items-center gap-1.5 rounded bg-background/60 px-2 py-1 font-mono text-[10px] text-muted-foreground">
                   <FileText className="h-3 w-3 shrink-0" />
-                  <span className="min-w-0 truncate" title={readPath}>
-                    {readPath}
+                  <span className="min-w-0 truncate" title={filePath}>
+                    {filePath}
                   </span>
-                  {(readMetaInfo?.offset != null || readMetaInfo?.limit != null) && (
-                    <span className="ml-auto shrink-0">
-                      {readMetaInfo?.offset != null && `offset ${readMetaInfo.offset}`}
-                      {readMetaInfo?.offset != null && readMetaInfo?.limit != null && " · "}
-                      {readMetaInfo?.limit != null && `limit ${readMetaInfo.limit}`}
-                    </span>
+                  {fileMetaParts.length > 0 && (
+                    <span className="ml-auto shrink-0">{fileMetaParts.join(" · ")}</span>
                   )}
                 </div>
               )}

--- a/src/components/chat/tool-use-card.tsx
+++ b/src/components/chat/tool-use-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { memo, useMemo } from "react";
-import { ChevronDown, ChevronRight, Wrench, AlertCircle, CheckCircle2, CircleSlash, Bot, Check, FileDiff } from "lucide-react";
+import { ChevronDown, ChevronRight, Wrench, AlertCircle, CheckCircle2, CircleSlash, Bot, Check, FileDiff, FileText } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { Spinner } from "@/components/ui/spinner";
 import { AnsiText } from "@/components/ui/ansi-text";
@@ -87,9 +87,16 @@ function stringifyArgs(args: unknown): string {
   }
 }
 
-/** Extract the file path from a read-style tool call (path/file/file_path
- *  arg, possibly stringified JSON), or null when there isn't one. */
-function toolFilePath(args: unknown): string | null {
+/** Parsed read-style tool call: file path plus optional paging args. */
+interface ReadMeta {
+  path: string | null;
+  offset?: number;
+  limit?: number;
+}
+
+/** Extract { path, offset, limit } from a read-style tool call (args may be an
+ *  object or stringified JSON). */
+function readMeta(args: unknown): ReadMeta {
   let value: unknown = args;
   if (typeof args === "string") {
     try {
@@ -98,14 +105,25 @@ function toolFilePath(args: unknown): string | null {
       value = args;
     }
   }
+  const meta: ReadMeta = { path: null };
   if (value && typeof value === "object") {
     const obj = value as Record<string, unknown>;
     for (const k of ["path", "file", "file_path", "filename"]) {
       const v = obj[k];
-      if (typeof v === "string" && v.trim()) return v.trim();
+      if (typeof v === "string" && v.trim()) {
+        meta.path = v.trim();
+        break;
+      }
     }
+    const num = (v: unknown): number | undefined => {
+      if (typeof v === "number" && Number.isFinite(v)) return v;
+      if (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))) return Number(v);
+      return undefined;
+    };
+    meta.offset = num(obj.offset);
+    meta.limit = num(obj.limit);
   }
-  return null;
+  return meta;
 }
 
 /** One oldText→newText replacement inside an edit tool call. */
@@ -375,7 +393,9 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
       ? flattenResultContent(block.result.content)
       : ""
     : "";
-  const readPath = /^read/i.test(block.name) ? toolFilePath(block.args) : null;
+  const isReadTool = /^read/i.test(block.name);
+  const readMetaInfo = useMemo(() => (isReadTool ? readMeta(block.args) : null), [isReadTool, block.args]);
+  const readPath = readMetaInfo?.path ?? null;
   const readExt = readPath ? fileExtension(readPath) : "";
   const highlighted = useMemo(
     () =>
@@ -471,7 +491,9 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
       )}
       {open && (
         <div className="space-y-2 px-2 pb-2 pt-1">
-          {block.args != null && (
+          {/* Read-style tools skip the raw JSON args entirely — the path and
+              paging args surface as a header on the result instead. */}
+          {block.args != null && !isReadTool && (
             <section>
               <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
                 {editInfo !== null ? t("tool.diff") : cmd !== null ? t("tool.command") : t("tool.args")}
@@ -493,6 +515,21 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
           {block.result && (
             <section>
               <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">{t("tool.result")}</div>
+              {readPath !== null && (
+                <div className="mb-1 flex items-center gap-1.5 rounded bg-background/60 px-2 py-1 font-mono text-[10px] text-muted-foreground">
+                  <FileText className="h-3 w-3 shrink-0" />
+                  <span className="min-w-0 truncate" title={readPath}>
+                    {readPath}
+                  </span>
+                  {(readMetaInfo?.offset != null || readMetaInfo?.limit != null) && (
+                    <span className="ml-auto shrink-0">
+                      {readMetaInfo?.offset != null && `offset ${readMetaInfo.offset}`}
+                      {readMetaInfo?.offset != null && readMetaInfo?.limit != null && " · "}
+                      {readMetaInfo?.limit != null && `limit ${readMetaInfo.limit}`}
+                    </span>
+                  )}
+                </div>
+              )}
               {highlighted !== null ? (
                 <pre
                   className={cn(

--- a/src/components/chat/tool-use-card.tsx
+++ b/src/components/chat/tool-use-card.tsx
@@ -397,8 +397,12 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
       ? flattenResultContent(block.result.content)
       : ""
     : "";
-  const isReadTool = /^read/i.test(block.name);
-  const isWriteTool = /^write/i.test(block.name);
+  // Only treat the built-in file tools as read/write cards. Prefix matching
+  // also catches unrelated tools such as read_mcp_resource and write_stdin,
+  // hiding their args and (for writes without `content`) their result body.
+  const normalizedToolName = block.name.trim().toLowerCase();
+  const isReadTool = normalizedToolName === "read" || normalizedToolName === "read_file";
+  const isWriteTool = normalizedToolName === "write" || normalizedToolName === "write_file";
   const isFileTool = isReadTool || isWriteTool;
   const fileMeta = useMemo(() => (isFileTool ? parseFileMeta(block.args) : null), [isFileTool, block.args]);
   const filePath = fileMeta?.path ?? null;

--- a/src/components/chat/tool-use-card.tsx
+++ b/src/components/chat/tool-use-card.tsx
@@ -88,17 +88,17 @@ function stringifyArgs(args: unknown): string {
 }
 
 /** Parsed file-tool (read/write) call: path plus optional paging args, and
- *  the written content size for write calls. */
+ *  the written content for write calls. */
 interface FileMeta {
   path: string | null;
   offset?: number;
   limit?: number;
-  /** Length of the `content` arg (write tool). */
-  size?: number;
+  /** The `content` arg (write tool) — rendered as the card body. */
+  content?: string;
 }
 
-/** Extract { path, offset, limit, size } from a read/write tool call (args may
- *  be an object or stringified JSON). */
+/** Extract { path, offset, limit, content } from a read/write tool call (args
+ *  may be an object or stringified JSON). */
 function parseFileMeta(args: unknown): FileMeta {
   let value: unknown = args;
   if (typeof args === "string") {
@@ -125,7 +125,7 @@ function parseFileMeta(args: unknown): FileMeta {
     };
     meta.offset = num(obj.offset);
     meta.limit = num(obj.limit);
-    if (typeof obj.content === "string") meta.size = obj.content.length;
+    if (typeof obj.content === "string") meta.content = obj.content;
   }
   return meta;
 }
@@ -397,19 +397,30 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
       ? flattenResultContent(block.result.content)
       : ""
     : "";
-  const isFileTool = /^(read|write)/i.test(block.name);
+  const isReadTool = /^read/i.test(block.name);
+  const isWriteTool = /^write/i.test(block.name);
+  const isFileTool = isReadTool || isWriteTool;
   const fileMeta = useMemo(() => (isFileTool ? parseFileMeta(block.args) : null), [isFileTool, block.args]);
   const filePath = fileMeta?.path ?? null;
-  // Only read-style calls surface file *content* in the result — write calls
-  // return a confirmation string, so only they get the syntax highlight.
-  const readPath = /^read/i.test(block.name) ? filePath : null;
-  const readExt = readPath ? fileExtension(readPath) : "";
+  const fileExt = filePath ? fileExtension(filePath) : "";
+  // What the card displays as the body: read → the result text (the file
+  // contents the model saw); write → the `content` arg itself (the result is
+  // only a confirmation string). On errors, fall back to the result text so an
+  // error message still shows with the warning tint.
+  const bodyText =
+    isReadTool || (isWriteTool && isError)
+      ? resultText
+      : isWriteTool
+        ? (fileMeta?.content ?? "")
+        : resultText;
+  // Highlight the body by file extension when a language can be pinned and
+  // there's something to highlight. Skipped on errors (keep the warning tint).
   const highlighted = useMemo(
     () =>
-      !isError && readPath !== null && languageForExtension(readExt)
-        ? highlightSource(resultText, readExt)
+      !isError && filePath !== null && bodyText !== "" && languageForExtension(fileExt)
+        ? highlightSource(bodyText, fileExt)
         : null,
-    [isError, readPath, readExt, resultText],
+    [isError, filePath, fileExt, bodyText],
   );
   const subagent = subagentInfo(block.result?.details);
   const outputInfo = toolOutputInfo(block.result?.details);
@@ -432,7 +443,7 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
     const parts: string[] = [];
     if (fileMeta?.offset != null) parts.push(`offset ${fileMeta.offset}`);
     if (fileMeta?.limit != null) parts.push(`limit ${fileMeta.limit}`);
-    if (fileMeta?.size != null) parts.push(formatBytes(fileMeta.size));
+    if (fileMeta?.content != null) parts.push(formatBytes(fileMeta.content.length));
     return parts;
   }, [fileMeta]);
   const preview = subagent
@@ -557,7 +568,7 @@ export const ToolUseCard = memo(function ToolUseCard({ id, block }: { id?: strin
                     isError && "text-warning dark:text-warning",
                   )}
                 >
-                  <AnsiText>{resultText}</AnsiText>
+                  <AnsiText>{bodyText}</AnsiText>
                 </pre>
               )}
               {outputInfo?.truncated && (

--- a/src/components/workspace/workspace-panel.tsx
+++ b/src/components/workspace/workspace-panel.tsx
@@ -41,7 +41,6 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal as XTermTerminal, type ITheme } from "@xterm/xterm";
-import hljs from "highlight.js/lib/common";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkCjkFriendly from "remark-cjk-friendly";
@@ -60,6 +59,7 @@ import {
   type BrowserViewState,
 } from "@/components/browser/browser-view";
 import { formatBytes } from "@/lib/artifact";
+import { escapeHtml, fileExtension, highlightSource, HLJS_THEME_CLASS } from "@/lib/highlight";
 import { useTranslation } from "@/lib/i18n";
 import { markdownComponents, markdownUrlTransform } from "@/lib/markdown";
 import { api } from "@/lib/tauri";
@@ -966,34 +966,7 @@ function SourcePreview({ text, ext }: { text: string; ext: string }) {
     <div
       className={cn(
         "h-full min-h-0 overflow-auto bg-white text-[#24292f] dark:bg-[#0d1117] dark:text-[#c9d1d9]",
-        "[&_.hljs-comment]:text-[#6e7781] dark:[&_.hljs-comment]:text-[#8b949e]",
-        "[&_.hljs-quote]:text-[#6e7781] dark:[&_.hljs-quote]:text-[#8b949e]",
-        "[&_.hljs-keyword]:text-[#cf222e] dark:[&_.hljs-keyword]:text-[#ff7b72]",
-        "[&_.hljs-selector-tag]:text-[#cf222e] dark:[&_.hljs-selector-tag]:text-[#ff7b72]",
-        "[&_.hljs-subst]:text-[#24292f] dark:[&_.hljs-subst]:text-[#c9d1d9]",
-        "[&_.hljs-number]:text-[#0550ae] dark:[&_.hljs-number]:text-[#79c0ff]",
-        "[&_.hljs-literal]:text-[#0550ae] dark:[&_.hljs-literal]:text-[#79c0ff]",
-        "[&_.hljs-variable]:text-[#953800] dark:[&_.hljs-variable]:text-[#ffa657]",
-        "[&_.hljs-template-variable]:text-[#953800] dark:[&_.hljs-template-variable]:text-[#ffa657]",
-        "[&_.hljs-string]:text-[#0a3069] dark:[&_.hljs-string]:text-[#a5d6ff]",
-        "[&_.hljs-doctag]:text-[#0a3069] dark:[&_.hljs-doctag]:text-[#a5d6ff]",
-        "[&_.hljs-title]:text-[#8250df] dark:[&_.hljs-title]:text-[#d2a8ff]",
-        "[&_.hljs-section]:text-[#8250df] dark:[&_.hljs-section]:text-[#d2a8ff]",
-        "[&_.hljs-selector-id]:text-[#8250df] dark:[&_.hljs-selector-id]:text-[#d2a8ff]",
-        "[&_.hljs-type]:text-[#953800] dark:[&_.hljs-type]:text-[#ffa657]",
-        "[&_.hljs-class_.hljs-title]:text-[#953800] dark:[&_.hljs-class_.hljs-title]:text-[#ffa657]",
-        "[&_.hljs-tag]:text-[#116329] dark:[&_.hljs-tag]:text-[#7ee787]",
-        "[&_.hljs-name]:text-[#116329] dark:[&_.hljs-name]:text-[#7ee787]",
-        "[&_.hljs-attribute]:text-[#0550ae] dark:[&_.hljs-attribute]:text-[#79c0ff]",
-        "[&_.hljs-regexp]:text-[#0a3069] dark:[&_.hljs-regexp]:text-[#a5d6ff]",
-        "[&_.hljs-symbol]:text-[#0a3069] dark:[&_.hljs-symbol]:text-[#a5d6ff]",
-        "[&_.hljs-bullet]:text-[#0a3069] dark:[&_.hljs-bullet]:text-[#a5d6ff]",
-        "[&_.hljs-built_in]:text-[#953800] dark:[&_.hljs-built_in]:text-[#ffa657]",
-        "[&_.hljs-builtin-name]:text-[#953800] dark:[&_.hljs-builtin-name]:text-[#ffa657]",
-        "[&_.hljs-meta]:text-[#6e7781] dark:[&_.hljs-meta]:text-[#8b949e]",
-        "[&_.hljs-deletion]:bg-[#ffebe9] [&_.hljs-deletion]:text-[#82071e] dark:[&_.hljs-deletion]:bg-[#490202] dark:[&_.hljs-deletion]:text-[#ffdcd7]",
-        "[&_.hljs-addition]:bg-[#dafbe1] [&_.hljs-addition]:text-[#116329] dark:[&_.hljs-addition]:bg-[#033a16] dark:[&_.hljs-addition]:text-[#aff5b4]",
-        "[&_.hljs-emphasis]:italic [&_.hljs-strong]:font-semibold",
+        HLJS_THEME_CLASS,
       )}
     >
       <pre className="min-h-full w-max min-w-full px-4 py-3 font-mono text-xs leading-relaxed">
@@ -1283,70 +1256,6 @@ function canToggleSource(kind: PreviewKind, ext: string): boolean {
 function needsText(kind: PreviewKind, mode: "preview" | "source", ext: string): boolean {
   return kind === "markdown" || kind === "text" || kind === "csv" || (mode === "source" && canToggleSource(kind, ext));
 }
-
-function fileExtension(name: string): string {
-  const index = name.lastIndexOf(".");
-  return index >= 0 ? name.slice(index + 1).toLowerCase() : "";
-}
-
-function highlightSource(text: string, ext: string): string {
-  const language = languageForExtension(ext);
-  try {
-    if (language && hljs.getLanguage(language)) {
-      return hljs.highlight(text, { language, ignoreIllegals: true }).value;
-    }
-    return hljs.highlightAuto(text).value;
-  } catch {
-    return escapeHtml(text);
-  }
-}
-
-function languageForExtension(ext: string): string | null {
-  const languages: Record<string, string> = {
-    bash: "bash",
-    c: "c",
-    cc: "cpp",
-    cpp: "cpp",
-    css: "css",
-    go: "go",
-    h: "cpp",
-    hpp: "cpp",
-    html: "xml",
-    htm: "xml",
-    java: "java",
-    js: "javascript",
-    json: "json",
-    jsx: "javascript",
-    log: "plaintext",
-    md: "markdown",
-    markdown: "markdown",
-    mdx: "markdown",
-    py: "python",
-    rs: "rust",
-    scss: "scss",
-    sh: "bash",
-    sql: "sql",
-    svg: "xml",
-    ts: "typescript",
-    tsx: "typescript",
-    toml: "ini",
-    txt: "plaintext",
-    xml: "xml",
-    yaml: "yaml",
-    yml: "yaml",
-    zsh: "bash",
-  };
-  return languages[ext] ?? null;
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
 function canPreviewOffice(ext: string): boolean {
   return isWordExt(ext) || isSpreadsheetExt(ext);
 }

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,0 +1,102 @@
+import hljs from "highlight.js/lib/common";
+
+/** Tailwind token colors (GitHub light + dark) applied to highlight.js output.
+ *  Spread onto a container whose children are hljs spans. */
+export const HLJS_THEME_CLASS = [
+  "[&_.hljs-comment]:text-[#6e7781] dark:[&_.hljs-comment]:text-[#8b949e]",
+  "[&_.hljs-quote]:text-[#6e7781] dark:[&_.hljs-quote]:text-[#8b949e]",
+  "[&_.hljs-keyword]:text-[#cf222e] dark:[&_.hljs-keyword]:text-[#ff7b72]",
+  "[&_.hljs-selector-tag]:text-[#cf222e] dark:[&_.hljs-selector-tag]:text-[#ff7b72]",
+  "[&_.hljs-subst]:text-[#24292f] dark:[&_.hljs-subst]:text-[#c9d1d9]",
+  "[&_.hljs-number]:text-[#0550ae] dark:[&_.hljs-number]:text-[#79c0ff]",
+  "[&_.hljs-literal]:text-[#0550ae] dark:[&_.hljs-literal]:text-[#79c0ff]",
+  "[&_.hljs-variable]:text-[#953800] dark:[&_.hljs-variable]:text-[#ffa657]",
+  "[&_.hljs-template-variable]:text-[#953800] dark:[&_.hljs-template-variable]:text-[#ffa657]",
+  "[&_.hljs-string]:text-[#0a3069] dark:[&_.hljs-string]:text-[#a5d6ff]",
+  "[&_.hljs-doctag]:text-[#0a3069] dark:[&_.hljs-doctag]:text-[#a5d6ff]",
+  "[&_.hljs-title]:text-[#8250df] dark:[&_.hljs-title]:text-[#d2a8ff]",
+  "[&_.hljs-section]:text-[#8250df] dark:[&_.hljs-section]:text-[#d2a8ff]",
+  "[&_.hljs-selector-id]:text-[#8250df] dark:[&_.hljs-selector-id]:text-[#d2a8ff]",
+  "[&_.hljs-type]:text-[#953800] dark:[&_.hljs-type]:text-[#ffa657]",
+  "[&_.hljs-class_.hljs-title]:text-[#953800] dark:[&_.hljs-class_.hljs-title]:text-[#ffa657]",
+  "[&_.hljs-tag]:text-[#116329] dark:[&_.hljs-tag]:text-[#7ee787]",
+  "[&_.hljs-name]:text-[#116329] dark:[&_.hljs-name]:text-[#7ee787]",
+  "[&_.hljs-attribute]:text-[#0550ae] dark:[&_.hljs-attribute]:text-[#79c0ff]",
+  "[&_.hljs-regexp]:text-[#0a3069] dark:[&_.hljs-regexp]:text-[#a5d6ff]",
+  "[&_.hljs-symbol]:text-[#0a3069] dark:[&_.hljs-symbol]:text-[#a5d6ff]",
+  "[&_.hljs-bullet]:text-[#0a3069] dark:[&_.hljs-bullet]:text-[#a5d6ff]",
+  "[&_.hljs-built_in]:text-[#953800] dark:[&_.hljs-built_in]:text-[#ffa657]",
+  "[&_.hljs-builtin-name]:text-[#953800] dark:[&_.hljs-builtin-name]:text-[#ffa657]",
+  "[&_.hljs-meta]:text-[#6e7781] dark:[&_.hljs-meta]:text-[#8b949e]",
+  "[&_.hljs-deletion]:bg-[#ffebe9] [&_.hljs-deletion]:text-[#82071e] dark:[&_.hljs-deletion]:bg-[#490202] dark:[&_.hljs-deletion]:text-[#ffdcd7]",
+  "[&_.hljs-addition]:bg-[#dafbe1] [&_.hljs-addition]:text-[#116329] dark:[&_.hljs-addition]:bg-[#033a16] dark:[&_.hljs-addition]:text-[#aff5b4]",
+  "[&_.hljs-emphasis]:italic [&_.hljs-strong]:font-semibold",
+] as const;
+
+/** Lowercase extension of a file name ("" when there is none). */
+export function fileExtension(name: string): string {
+  const index = name.lastIndexOf(".");
+  return index >= 0 ? name.slice(index + 1).toLowerCase() : "";
+}
+
+/** Map a file extension to a highlight.js language name, or null. */
+export function languageForExtension(ext: string): string | null {
+  const languages: Record<string, string> = {
+    bash: "bash",
+    c: "c",
+    cc: "cpp",
+    cpp: "cpp",
+    css: "css",
+    go: "go",
+    h: "cpp",
+    hpp: "cpp",
+    html: "xml",
+    htm: "xml",
+    java: "java",
+    js: "javascript",
+    json: "json",
+    jsx: "javascript",
+    log: "plaintext",
+    md: "markdown",
+    markdown: "markdown",
+    mdx: "markdown",
+    py: "python",
+    rs: "rust",
+    scss: "scss",
+    sh: "bash",
+    sql: "sql",
+    svg: "xml",
+    ts: "typescript",
+    tsx: "typescript",
+    toml: "ini",
+    txt: "plaintext",
+    xml: "xml",
+    yaml: "yaml",
+    yml: "yaml",
+    zsh: "bash",
+  };
+  return languages[ext] ?? null;
+}
+
+/** Escape text for safe injection into a code block. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Syntax-highlight source text by extension, falling back to auto-detection,
+ *  then plain escaping when highlighting fails. Returns HTML. */
+export function highlightSource(text: string, ext: string): string {
+  const language = languageForExtension(ext);
+  try {
+    if (language && hljs.getLanguage(language)) {
+      return hljs.highlight(text, { language, ignoreIllegals: true }).value;
+    }
+    return hljs.highlightAuto(text).value;
+  } catch {
+    return escapeHtml(text);
+  }
+}

--- a/src/lib/i18n/messages/chat.ts
+++ b/src/lib/i18n/messages/chat.ts
@@ -178,6 +178,8 @@ export const chat = {
     "tool.interrupted": "interrupted",
     "tool.done": "done",
     "tool.args": "args",
+    "tool.command": "command",
+    "tool.diff": "diff",
     "tool.result": "result",
     "tool.outputTruncated": "Preview limited · {size} total",
     "tool.openFullOutput": "Open full output",
@@ -383,6 +385,8 @@ export const chat = {
     "tool.interrupted": "已中断",
     "tool.done": "完成",
     "tool.args": "参数",
+    "tool.command": "命令",
+    "tool.diff": "差异",
     "tool.result": "结果",
     "tool.outputTruncated": "预览已截断 · 共 {size}",
     "tool.openFullOutput": "打开完整输出",
@@ -485,6 +489,8 @@ export const chat = {
     "tool.running": "実行中",
     "tool.done": "完了",
     "tool.args": "引数",
+    "tool.command": "コマンド",
+    "tool.diff": "差分",
     "tool.result": "結果",
 
     "vision.image": "{count} 枚の画像",
@@ -581,6 +587,8 @@ export const chat = {
     "tool.running": "실행 중",
     "tool.done": "완료",
     "tool.args": "인수",
+    "tool.command": "명령",
+    "tool.diff": "diff",
     "tool.result": "결과",
 
     "vision.image": "이미지 {count}개",
@@ -677,6 +685,8 @@ export const chat = {
     "tool.running": "en ejecución",
     "tool.done": "listo",
     "tool.args": "argumentos",
+    "tool.command": "comando",
+    "tool.diff": "diff",
     "tool.result": "resultado",
 
     "vision.image": "{count} imagen",
@@ -773,6 +783,8 @@ export const chat = {
     "tool.running": "em execução",
     "tool.done": "concluído",
     "tool.args": "argumentos",
+    "tool.command": "comando",
+    "tool.diff": "diff",
     "tool.result": "resultado",
 
     "vision.image": "{count} imagem",
@@ -869,6 +881,8 @@ export const chat = {
     "tool.running": "en cours",
     "tool.done": "terminé",
     "tool.args": "arguments",
+    "tool.command": "commande",
+    "tool.diff": "diff",
     "tool.result": "résultat",
 
     "vision.image": "{count} image",
@@ -965,6 +979,8 @@ export const chat = {
     "tool.running": "läuft",
     "tool.done": "fertig",
     "tool.args": "Argumente",
+    "tool.command": "Befehl",
+    "tool.diff": "diff",
     "tool.result": "Ergebnis",
 
     "vision.image": "{count} Bild",
@@ -1061,6 +1077,8 @@ export const chat = {
     "tool.running": "in esecuzione",
     "tool.done": "completato",
     "tool.args": "argomenti",
+    "tool.command": "comando",
+    "tool.diff": "diff",
     "tool.result": "risultato",
 
     "vision.image": "{count} immagine",
@@ -1157,6 +1175,8 @@ export const chat = {
     "tool.running": "выполняется",
     "tool.done": "готово",
     "tool.args": "аргументы",
+    "tool.command": "команда",
+    "tool.diff": "diff",
     "tool.result": "результат",
 
     "vision.image": "{count} изображение",


### PR DESCRIPTION
## Summary

Improves how tool calls render in the conversation timeline so a settled step shows what it actually did instead of a raw JSON envelope.

### bash — show the command, not JSON
- Collapsed preview shows `$ <command>`; the expanded args section renders the command terminal-style with a `$` prefix instead of the `{"command": "…"}` JSON dump
- Detects bash-shaped calls by tool name (`/bash/i`) or a `command`/`cmd` arg field; handles stringified-JSON args

<img width="1312" height="316" alt="image" src="https://github.com/user-attachments/assets/a39d797a-a9fb-4495-86a0-2f902e9fb06a" />

### read — file header + syntax-highlighted content
- Read-style calls skip the raw JSON args section entirely
- The result gets a mono file header: path plus paging args (`offset N · limit M`) when present
- The file contents are syntax-highlighted with highlight.js based on the file's extension (`.tsx` → TypeScript colors, light/dark aware); skipped on error results (keeps the warning tint)
<img width="1330" height="418" alt="image" src="https://github.com/user-attachments/assets/185666a4-cd52-427d-8da4-ecc77476f2fa" />

### write — file header + written content
- Write-style calls also skip the raw JSON args section
- The result shows the target path plus the written size, and renders the `content` arg itself as the body — syntax-highlighted by extension, same as read
- On errors it falls back to the result text so the error message keeps the warning tint

<img width="1326" height="296" alt="image" src="https://github.com/user-attachments/assets/998aa899-07c6-4cb0-9f6b-774aa1e8e13b" />

### edit — rendered as a unified diff
- `edit` tool calls (an `edits: [{oldText, newText}]` array or a bare pair) render as a git-style diff: file header with path + diffstat (`+N -M`), red `-` deletion lines, green `+` additions, dim context
- Line-level LCS diff with an 800-line-per-side safety cap; empty old/new sides produce pure insertions/deletions; multi-edit hunks get `1 / N` separators
- Collapsed preview shows `path · +N -M`

<img width="1334" height="408" alt="image" src="https://github.com/user-attachments/assets/0de685e6-38a8-47d2-9f0e-4122c198c267" />


### i18n
- Adds `tool.command` and `tool.diff` keys in all 10 locales

## Notes
- Diff engine (LCS) and rendering live in `tool-use-card.tsx` with no new dependencies (highlight.js was already a dependency)
- New shared `src/lib/highlight.ts` extracts the hljs theme + language mapping that were previously private to `workspace-panel.tsx`, now reused by both the workspace file preview and the chat tool card
- Verified with `tsc --noEmit` and a functional test of the diff/meta-parsing logic

## Files
- `src/components/chat/tool-use-card.tsx` — bash command display, read/write file headers + highlighting, edit diff
- `src/lib/highlight.ts` — new shared highlighting module
- `src/components/workspace/workspace-panel.tsx` — refactored to use the shared module (-95 lines)
- `src/lib/i18n/messages/chat.ts` — new `tool.command` / `tool.diff` keys
