### PR TITLE
perf: cut idle GPU by making main window opaque and dropping per-fram…

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
         "minWidth": 700,
         "minHeight": 480,
         "decorations": true,
-        "transparent": true,
+        "transparent": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "backgroundThrottling": "throttle",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -429,7 +429,11 @@
     linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
-  filter: drop-shadow(0 0 2px color-mix(in oklab, var(--composer-runner) 55%, transparent));
+  /* No filter here, deliberately: a drop-shadow on a layer whose background
+     is animated re-runs the whole blur every animation frame (steady GPU
+     work — the ring is small, but the filter forces a separate raster pass
+     plus a window-sized backdrop read on each tick). The moving gradient
+     highlight reads as the glow on its own. */
   animation: composer-border-spin 2.8s linear infinite;
 }
 


### PR DESCRIPTION
…e border blur

The main window's DOM paints a full-window opaque background, so transparent:true only kept an alpha channel alive on the webview surface and forced the compositor down a blend path (steady idle GPU, and WebKit loses its opaque fast paths). The frameless launcher/HUD windows keep their transparency.

The streaming composer border animated a conic-gradient ring plus a drop-shadow filter; the filter made WebKit re-run the blur every animation frame. The gradient highlight reads as the glow on its own, so the filter is dropped.