### PR TITLE
style: apply cargo fmt to cli_backend

### DIFF
--- a/src-tauri/src/cli_backend.rs
+++ b/src-tauri/src/cli_backend.rs
@@ -227,13 +227,17 @@ async fn probe_grok_defaults() -> Option<CliDefaults> {
         .iter()
         .filter_map(|entry| {
             let id = entry.get("modelId")?.as_str()?.to_string();
-            let label = entry.get("name").and_then(Value::as_str).unwrap_or(&id).to_string();
+            let label = entry
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(&id)
+                .to_string();
             Some(CliModelEntry { id, label })
         })
         .collect();
-    let selected = available.iter().find(|entry| {
-        entry.get("modelId").and_then(Value::as_str) == model.as_deref()
-    });
+    let selected = available
+        .iter()
+        .find(|entry| entry.get("modelId").and_then(Value::as_str) == model.as_deref());
     let effort = selected
         .and_then(|entry| entry.pointer("/_meta/reasoningEffort"))
         .and_then(Value::as_str)


### PR DESCRIPTION
CI's `cargo fmt --check` step has been failing on `main` since the 0.3.54 version bump, which skipped clippy / compile / test on every push since.

Two chained expressions in `src-tauri/src/cli_backend.rs` (the `name` lookup at :227 and the `find` at :234) exceeded the line width. This applies `cargo fmt` to them — no behavior change.

Verified locally: `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)